### PR TITLE
Add merch showcase section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,22 +1,15 @@
 theme: chulapa-jekyll
-
-
 # Site settings
-# These are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
-
 title: TeamSerio.us
 email: we-do-not-have-email@example.com
-description: >- # this means to ignore newlines until "baseurl:"
+description: >-
   Web Home Of Team Serious.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://teamserio.us" # the base hostname & protocol for your site, e.g. http://example.com
-#twitter_username: jekyllrb
-github_username:  rykerwilliams
+baseurl: ""
+url: "https://teamserio.us"
+github_username: rykerwilliams
 timezone: America/New_York
 og_image: assets/images/site/SeriousManaHR-blacklogo-gray.png
+
 author:
   name: Rajah James
   avatar: assets/images/avatars/310221.jpg
@@ -31,157 +24,120 @@ author:
       icon: "fab fa-facebook"
       label: "My personal FB"
 
-# Search providers
-# Available free search engines:
-# - lunr https://lunrjs.com/
 search:
-  provider              : lunr #Select a provider for enable search: lunr, algolia, google
-  label                 :  #default ["Search"] Text on navbar when search is enabled
-  landing_page          :  #default ["/search"] Link on navbar
-  lunr_maxwords         :  #default [30] lunr only - May slow down your site build
+  provider : lunr
+  label :
+  landing_page :
+  lunr_maxwords :
 
 comments:
-  provider:         #Use 'disqus' https://disqus.com/ or 'giscus' https://giscus.app/
-  disqus_shortname: #Your site id : check your address https://{{ disqus.shortname }}.disqus.com/admin/
+  provider:
+  disqus_shortname:
 
-# Navbar:
-#   "brand" options would be set on the left side of your navbar
-#   "nav" would be set on the right side. Two-level nav links available
 navbar:
-  style : dual 
+  style : dual
   brand:
     title:
     img: "./assets/images/site/ohio.png"
   nav:
-  - title   : Posts #Label
-    url     : /posts/  #url
-  - title   : Calendar
-    url     : /calendar
-  - title   : Tags
-    url     : /tags
-  - title   : Categories
-    url     : /categories
-  - title   : Media #Label
-    child:
-      - title : Full Warning Podcast
-        url: /full-warning/  #url
-      - title : Full Warning YouTube
-        url: https://www.youtube.com/@FullWarningPodcast #url
-      - title : Serious Vintage Podcast
-        url: https://www.eternalcentral.com/seriousvintagepodcast/  #url
-      - title : Serious Vintage YouTube
-        url: https://www.youtube.com/@SeriousVintageCast #url
+    - title : Posts
+      url : /posts/
+    - title : Calendar
+      url : /calendar
+    - title : Tags
+      url : /tags
+    - title : Categories
+      url : /categories
+    - title : Merch
+      url : /merch/
+    - title : Media
+      child:
+        - title : Full Warning Podcast
+          url: /full-warning/
+        - title : Full Warning YouTube
+          url: https://www.youtube.com/@FullWarningPodcast
+        - title : Serious Vintage Podcast
+          url: https://www.eternalcentral.com/seriousvintagepodcast/
+        - title : Serious Vintage YouTube
+          url: https://www.youtube.com/@SeriousVintageCast
+
 footer:
   copyright: "&copy; 2024 Team Serious"
   links:
     - label: "RSS"
       icon: "fa fa-rss"
-      url:  "./atom.xml"
-    # - label: "Twitter"
-    #   icon: "fab fa-twitter"
-    #   url: https://twitter.com/
-    # - label: "Facebook"
-    #   icon: "fab fa-facebook"
-    #   url: https://www.facebook.com
+      url: "./atom.xml"
 
-# C. Theme Settings
-# Google Fonts https://fonts.google.com/, add as many as you need
 googlefonts:
- # - url : # 'https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700;900&display=swap'
 
-# Theme and colors
 chulapa-skin:
-  skin   : twitter-dim
-  highlight   : "ZENBURN" #or any other name, default is 'DEFAULT' style
-  autothemer    :  false # Bool: Use autotheming
-  vars          :
-    primary     : lightskyblue #default ["#007bff"] - Bootstrap blue
+  skin : twitter-dim
+  highlight : "ZENBURN"
+  autothemer : false
+  vars :
+    primary : lightskyblue
 
-# D. Jekyll Defaults and collections: see https://jekyllrb.com/
-
-# Blog pagination: on this site /blog/index.html. https://jekyllrb.com/docs/pagination/
 paginate: 4
 paginate_path: "/posts/page:num/"
-paginator_maxnum: 3  #default[3] Custom: max of number to be displayed on the paginator
+paginator_maxnum: 3
 
-# Collections https://jekyllrb.com/docs/step-by-step/09-collections/
 collections:
   posts:
     output: true
     permalink : /posts/:year:month:day_:title
-# collections_dir     :
-permalink           : /:year:month:day_:title/
+  merch:
+    output: true
+    permalink: /merch/:name
 
-# Defaults https://jekyllrb.com/docs/configuration/front-matter-defaults/
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
     values:
       layout: "default"
       header_type: "base"
-      include_on_search   : false
-      cloudtag_url        : /tags #This is where the link on tags would redirect
-      cloudcategory_url   : /categories #This is where the link on categories would redirect
-  -
-    scope:
+      include_on_search : false
+      cloudtag_url : /tags
+      cloudcategory_url : /categories
+  - scope:
       path: ""
       type: "posts"
     values:
-      header_type       : "post"
+      header_type : "post"
       include_on_search : true
-      include_on_feed   : true
-      show_date         : true
-      show_related      : true
-      show_bottomnavs   : true
-      show_sociallinks  : true
-      show_comments     : true
-      show_tags         : true
-      show_categories   : true
-      show_author       : true
-      show_breadcrumb   : true
-      breadcrumb_list   :
+      include_on_feed : true
+      show_date : true
+      show_related : true
+      show_bottomnavs : true
+      show_sociallinks : true
+      show_comments : true
+      show_tags : true
+      show_categories : true
+      show_author : true
+      show_breadcrumb : true
+      breadcrumb_list :
         - label: Posts
           url: /posts
+  - scope:
+      path: ""
+      type: "merch"
+    values:
+      layout: "merch-item"
+      include_on_search: false
 
-# Build settings
 plugins:
   - jekyll-paginate
   - jekyll-include-cache
   - jekyll-sitemap
-  
-# Exclude from processing.
-# The following items will not be processed, by default.
-# Any item listed under the `exclude:` key here will be automatically added to
-# the internal "default list".
-#
-# Excluded items can be processed by explicitly listing the directories or
-# their entries' file path in the `include:` list.
-#
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
 
 include:
- - _pages
-#  - _plugins
+  - _pages
 
-# Conversion
 markdown: kramdown
 highlighter: rouge
 lsi: false
 excerpt_separator: "\n\n"
 incremental: false
 
-# Markdown Processing
 kramdown:
   input: GFM
   hard_wrap: false
@@ -193,8 +149,6 @@ kramdown:
   smart_quotes: lsquo,rsquo,ldquo,rdquo
   enable_coderay: false
 
- # Sass/SCSS
 sass:
   sass_dir: _sass
-  style: compressed # https://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
-  
+  style: compressed

--- a/_includes/merch-card.html
+++ b/_includes/merch-card.html
@@ -1,0 +1,44 @@
+{% assign item = include.item %}
+<div class="col-sm-6 col-md-4 col-lg-3 mb-4">
+  <div class="card h-100" style="background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1);">
+    {% if item.header_img %}
+    <a href="{{ item.url | relative_url }}">
+      <img src="{{ item.header_img | relative_url }}"
+           class="card-img-top"
+           alt="{{ item.title }}"
+           style="height:200px; object-fit:cover;">
+    </a>
+    {% endif %}
+    <div class="card-body d-flex flex-column">
+      <div class="d-flex justify-content-between align-items-start mb-1">
+        <h5 class="card-title mb-0">
+          <a href="{{ item.url | relative_url }}" class="text-light">{{ item.title }}</a>
+        </h5>
+        {% if item.available %}
+        <span class="badge badge-success ml-2" style="white-space:nowrap;">Available</span>
+        {% else %}
+        <span class="badge badge-secondary ml-2" style="white-space:nowrap;">Unavailable</span>
+        {% endif %}
+      </div>
+
+      {% if item.item_type %}
+      <small class="text-muted mb-2">{{ item.item_type }}</small>
+      {% endif %}
+
+      {% if item.description %}
+      <p class="card-text small mt-1" style="flex-grow:1;">{{ item.description | truncate: 100 }}</p>
+      {% endif %}
+
+      <div class="d-flex align-items-center mt-auto pt-2" style="border-top:1px solid rgba(255,255,255,0.08);">
+        {% if item.creator_avatar %}
+        <img src="{{ item.creator_avatar | relative_url }}"
+             class="rounded-circle mr-2"
+             width="28" height="28"
+             alt="{{ item.creator }}"
+             style="object-fit:cover;">
+        {% endif %}
+        <small class="text-muted">{{ item.creator }}</small>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_layouts/merch-item.html
+++ b/_layouts/merch-item.html
@@ -1,0 +1,76 @@
+---
+layout: default
+---
+{% assign item = page %}
+
+<div class="container mt-4 mb-5">
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item"><a href="/merch/">Merch</a></li>
+      <li class="breadcrumb-item active" aria-current="page">{{ item.title }}</li>
+    </ol>
+  </nav>
+
+  <div class="row">
+    <div class="col-md-6 mb-4">
+      {% if item.header_img %}
+      <img src="{{ item.header_img | relative_url }}" class="img-fluid rounded shadow-sm mb-3" alt="{{ item.title }}" style="width:100%; max-height:420px; object-fit:cover;">
+      {% endif %}
+      {% if item.images %}
+      <div class="row no-gutters">
+        {% for img in item.images %}
+        <div class="col-4 p-1">
+          <a href="{{ img | relative_url }}" target="_blank">
+            <img src="{{ img | relative_url }}" class="img-fluid rounded" alt="{{ item.title }} {{ forloop.index }}" style="height:90px; width:100%; object-fit:cover;">
+          </a>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+
+    <div class="col-md-6">
+      <h1 class="mb-1">{{ item.title }}</h1>
+      {% if item.subtitle %}<p class="text-muted lead mb-3">{{ item.subtitle }}</p>{% endif %}
+
+      <div class="d-flex align-items-center mb-3">
+        {% if item.creator_avatar %}
+        <img src="{{ item.creator_avatar | relative_url }}" class="rounded-circle mr-3" width="48" height="48" alt="{{ item.creator }}" style="object-fit:cover;">
+        {% endif %}
+        <div>
+          <small class="text-muted d-block">Created by</small>
+          <strong>{{ item.creator }}</strong>
+          {% if item.creator_location %}<small class="text-muted ml-1">- {{ item.creator_location }}</small>{% endif %}
+        </div>
+      </div>
+
+      <div class="mb-3">
+        {% if item.item_type %}<span class="badge badge-info mr-1">{{ item.item_type }}</span>{% endif %}
+        {% if item.available %}<span class="badge badge-success">Available</span>
+        {% else %}<span class="badge badge-secondary">Not Currently Available</span>{% endif %}
+      </div>
+
+      <div class="merch-description mb-4">{{ content }}</div>
+
+      {% if item.available %}
+      <div class="alert alert-info">
+        <h5 class="alert-heading">Interested?</h5>
+        <p class="mb-0">{{ item.contact }}</p>
+      </div>
+      {% else %}
+      <div class="alert alert-secondary">
+        <h5 class="alert-heading">Not Currently Available</h5>
+        <p class="mb-0">Reach out to <strong>{{ item.creator }}</strong> for future availability.</p>
+      </div>
+      {% endif %}
+
+      {% if item.tags %}
+      <div class="mt-3">
+        {% for tag in item.tags %}
+        <a href="{{ site.cloudtag_url }}/{{ tag | slugify }}" class="badge badge-primary mr-1">{{ tag }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/_merch/example-team-serious-tee.md
+++ b/_merch/example-team-serious-tee.md
@@ -1,0 +1,21 @@
+---
+layout: merch-item
+title: "Team Serious T-Shirt"
+subtitle: "Classic logo tee"
+creator: "Rajah James"
+creator_avatar: /assets/images/avatars/310221.jpg
+creator_location: "Ohio, US"
+contact: "Hit up Rajah on Discord or at a Team Serious event to snag one."
+available: true
+item_type: apparel
+header_img: /assets/images/merch/example/tee-placeholder.jpg
+images: []
+tags: [merch, apparel]
+category: merch
+---
+
+The classic Team Serious logo tee. Comfortable, 100% cotton, available in a few sizes. Grab one at the next event or reach out directly.
+
+- Screen printed Team Serious logo
+- Available in S, M, L, XL
+- Black

--- a/merch/index.html
+++ b/merch/index.html
@@ -1,0 +1,88 @@
+---
+layout: default
+title: Merch
+header_type: base
+permalink: /merch/
+---
+
+<div class="container mt-4 mb-5">
+  <div class="row mb-4">
+    <div class="col">
+      <h1>Team Serious Merch</h1>
+      <p class="lead text-muted">Gear, art, and accessories created by Team Serious members. Nothing here has an add-to-cart button &mdash; just reach out to the creator directly if something catches your eye.</p>
+    </div>
+  </div>
+
+  {% assign all_merch = site.merch %}
+  {% assign creators = all_merch | map: "creator" | uniq | sort %}
+
+  {% if all_merch.size > 0 %}
+
+  <!-- Filter bar -->
+  <div class="mb-4 d-flex flex-wrap align-items-center" id="merch-filters">
+    <span class="mr-2 text-muted small">Filter by creator:</span>
+    <button class="btn btn-sm btn-outline-light mr-1 mb-1 active" data-creator="all">All</button>
+    {% for creator in creators %}
+    <button class="btn btn-sm btn-outline-light mr-1 mb-1" data-creator="{{ creator | slugify }}">{{ creator }}</button>
+    {% endfor %}
+  </div>
+
+  <div class="row" id="merch-grid">
+    {% for item in all_merch %}
+    <div class="merch-card-wrapper col-sm-6 col-md-4 col-lg-3 mb-4" data-creator="{{ item.creator | slugify }}">
+      <div class="card h-100" style="background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1);">
+        {% if item.header_img %}
+        <a href="{{ item.url | relative_url }}">
+          <img src="{{ item.header_img | relative_url }}" class="card-img-top" alt="{{ item.title }}" style="height:200px; object-fit:cover;">
+        </a>
+        {% endif %}
+        <div class="card-body d-flex flex-column">
+          <div class="d-flex justify-content-between align-items-start mb-1">
+            <h5 class="card-title mb-0">
+              <a href="{{ item.url | relative_url }}" class="text-light">{{ item.title }}</a>
+            </h5>
+            {% if item.available %}
+            <span class="badge badge-success ml-2">Available</span>
+            {% else %}
+            <span class="badge badge-secondary ml-2">Unavailable</span>
+            {% endif %}
+          </div>
+          {% if item.item_type %}
+          <small class="text-muted mb-2">{{ item.item_type }}</small>
+          {% endif %}
+          {% if item.excerpt %}
+          <p class="card-text small mt-1" style="flex-grow:1;">{{ item.excerpt | strip_html | truncate: 100 }}</p>
+          {% endif %}
+          <div class="d-flex align-items-center mt-auto pt-2" style="border-top:1px solid rgba(255,255,255,0.08);">
+            {% if item.creator_avatar %}
+            <img src="{{ item.creator_avatar | relative_url }}" class="rounded-circle mr-2" width="28" height="28" alt="{{ item.creator }}" style="object-fit:cover;">
+            {% endif %}
+            <small class="text-muted">{{ item.creator }}</small>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  {% else %}
+  <div class="alert alert-info">No merch items yet &mdash; check back soon!</div>
+  {% endif %}
+</div>
+
+<script>
+(function() {
+  const buttons = document.querySelectorAll('#merch-filters button');
+  const cards = document.querySelectorAll('.merch-card-wrapper');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', function() {
+      buttons.forEach(b => b.classList.remove('active'));
+      this.classList.add('active');
+      const filter = this.dataset.creator;
+      cards.forEach(card => {
+        card.style.display = (filter === 'all' || card.dataset.creator === filter) ? '' : 'none';
+      });
+    });
+  });
+})();
+</script>


### PR DESCRIPTION
## Merch Showcase Section

Adds a no-checkout merch gallery so Team Serious members can advertise merchandise they've created. No buy buttons — just a place to show off gear and point interested folks at the creator directly.

### What's included

**New Jekyll collection: `_merch/`**
- Each item is a markdown file with front matter for title, creator, images, item type, availability, and contact info
- - Example item included: `example-team-serious-tee.md`
**New layout: `_layouts/merch-item.html`**
- Two-column item detail page (image + info)
- - Creator avatar, name, and location (matches post author style)
- - Availability badge + "Interested?" callout box with contact info (no buy button)
- - Tag badges linking into the existing tag system
**New include: `_includes/merch-card.html`**
- Reusable Bootstrap card for use in the gallery and any future spotlights
**New gallery index: `merch/index.html`**
- Bootstrap card grid of all merch items
- - Client-side filter by creator (no backend needed)
**`_config.yml` updates**
- Added `merch` collection with `permalink: /merch/:name`
- - Added default layout (`merch-item`) for all merch items
- - Added **Merch** nav link between Categories and Media
### Adding new items
Drop a `.md` file in `_merch/` following the front matter pattern in the example item. Images go in `assets/images/merch/[creator-slug]/[item-slug]/`.